### PR TITLE
Mirror of aws aws-sdk-cpp#783

### DIFF
--- a/aws-cpp-sdk-core/include/aws/core/client/AWSClient.h
+++ b/aws-cpp-sdk-core/include/aws/core/client/AWSClient.h
@@ -161,6 +161,13 @@ namespace Aws
 
         protected:
             /**
+             * Validates HttpResponse body in cases where it's possible to get 200 response code,
+             * but the request failed and the body contains an error (e.g. Complete multipart upload)
+             */
+            HttpResponseOutcome GetHttpOutcome(const std::shared_ptr<Http::HttpRequest>& httpRequest,
+                const std::shared_ptr<Http::HttpResponse>& httpResponse) const;
+
+            /**
              * Calls AttemptOnRequest until it either, succeeds, runs out of retries from the retry strategy,
              * or encounters and error that is not retryable.
              */

--- a/aws-cpp-sdk-core/source/client/AWSClient.cpp
+++ b/aws-cpp-sdk-core/source/client/AWSClient.cpp
@@ -274,7 +274,34 @@ static bool DoesResponseGenerateError(const std::shared_ptr<HttpResponse>& respo
 
 }
 
-HttpResponseOutcome AWSClient::AttemptOneRequest(const Aws::Http::URI& uri,
+HttpResponseOutcome AWSClient::GetHttpOutcome(const std::shared_ptr<Http::HttpRequest>& httpRequest,
+    const std::shared_ptr<Http::HttpResponse>& httpResponse) const
+{
+    if (httpRequest->GetMethod() != HttpMethod::HTTP_GET && 
+            httpResponse->GetContentType() == "application/xml") {
+        // Don't just trust the response status code; check the response body
+        // See http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadComplete.html
+        XmlDocument doc = XmlDocument::CreateFromXmlStream(httpResponse->GetResponseBody());
+        if (doc.WasParseSuccessful()) {
+            XmlNode errorNode = doc.GetRootElement();
+            if (errorNode.IsNull()) {
+                return HttpResponseOutcome(BuildAWSError(nullptr));
+            }
+
+            if (errorNode.GetName() == "Error") {
+                AWS_LOG_DEBUG(AWS_CLIENT_LOG_TAG, "Request returned error. Attempting to generate appropriate error codes from response");
+                return HttpResponseOutcome(BuildAWSError(httpResponse));
+            }
+        }
+
+    }
+
+    AWS_LOG_DEBUG(AWS_CLIENT_LOG_TAG, "Request returned successful response.");
+    return HttpResponseOutcome(httpResponse);
+}
+
+
+HttpResponseOutcome AWSClient::AttemptOneRequest(const Aws::String& uri,
     const Aws::AmazonWebServiceRequest& request,
     HttpMethod method,
     const char* signerName) const
@@ -298,9 +325,7 @@ HttpResponseOutcome AWSClient::AttemptOneRequest(const Aws::Http::URI& uri,
         return HttpResponseOutcome(BuildAWSError(httpResponse));
     }
 
-    AWS_LOGSTREAM_DEBUG(AWS_CLIENT_LOG_TAG, "Request returned successful response.");
-
-    return HttpResponseOutcome(httpResponse);
+    return GetHttpOutcome(httpRequest, httpResponse);
 }
 
 HttpResponseOutcome AWSClient::AttemptOneRequest(const Aws::Http::URI& uri, HttpMethod method, const char* signerName, const char* requestName) const
@@ -328,9 +353,7 @@ HttpResponseOutcome AWSClient::AttemptOneRequest(const Aws::Http::URI& uri, Http
         return HttpResponseOutcome(BuildAWSError(httpResponse));
     }
 
-    AWS_LOGSTREAM_DEBUG(AWS_CLIENT_LOG_TAG, "Request returned successful response.");
-
-    return HttpResponseOutcome(httpResponse);
+    return GetHttpOutcome(httpRequest, httpResponse);
 }
 
 StreamOutcome AWSClient::MakeRequestWithUnparsedResponse(const Aws::Http::URI& uri,


### PR DESCRIPTION
Mirror of aws aws-sdk-cpp#783
The SDK relies on HTTP status codes to determine whether or not the operation succeeded. However, in certain APIs such as CompleteMultipartUpload, the API may return 200 OK with an error in the response body. In those cases, the response body needs to be inspected for errors. This fix only checks response bodies of non-GET requests that return XML as the response type. #658 #781 
