### PR TITLE
Mirror of aws aws-sdk-cpp#741

### DIFF
--- a/aws-cpp-sdk-s3/include/aws/s3/model/CompletedMultipartUpload.h
+++ b/aws-cpp-sdk-s3/include/aws/s3/model/CompletedMultipartUpload.h
@@ -63,6 +63,9 @@ namespace Model
 
     
     inline CompletedMultipartUpload& AddParts(CompletedPart&& value) { m_partsHasBeenSet = true; m_parts.push_back(std::move(value)); return *this; }
+    
+    
+    inline CompletedMultipartUpload& SortParts() { std::sort(m_parts.begin(), m_parts.end(), [](const CompletedPart& lhs, const CompletedPart& rhs) { return lhs.GetPartNumber() < rhs.GetPartNumber(); }); return *this; }
 
   private:
 


### PR DESCRIPTION
Mirror of aws aws-sdk-cpp#741
The `CompletedMultipartUpload` object is used to track part tags when performing a multipart upload to AWS S3 service. Since the parts are not necessarily sent in order and the `CompletedMultipartUploadRequest` needs the part sorted in increasing order, the new `SortParts()` function is convenient, it prevents making an unnecessary copy of the `CompletedPart`vector to sort its content.

