### PR TITLE
Mirror of aws aws-sdk-cpp#740

### DIFF
--- a/aws-cpp-sdk-core/source/utils/crypto/openssl/CryptoImpl.cpp
+++ b/aws-cpp-sdk-core/source/utils/crypto/openssl/CryptoImpl.cpp
@@ -169,7 +169,7 @@ namespace Aws
                 EVP_DigestInit_ex(ctx, EVP_md5(), nullptr);
 
                 auto currentPos = stream.tellg();
-                if (currentPos == -1)
+                if (currentPos == std::streampos(-1))
                 {
                     currentPos = 0;
                     stream.clear();
@@ -218,7 +218,7 @@ namespace Aws
                 EVP_DigestInit_ex(ctx, EVP_sha256(), nullptr);
 
                 auto currentPos = stream.tellg();
-                if (currentPos == -1)
+                if (currentPos == std::streampos(-1))
                 {
                     currentPos = 0;
                     stream.clear();


### PR DESCRIPTION
Mirror of aws aws-sdk-cpp#740
Adding this type cast seems required for compilation with Visual Studio 2017 of 'core' component using openssl.
