### PR TITLE
Mirror of aws aws-sdk-cpp#681

### DIFF
--- a/aws-cpp-sdk-text-to-speech/source/text-to-speech/windows/WaveOutPCMOutputDriver.cpp
+++ b/aws-cpp-sdk-text-to-speech/source/text-to-speech/windows/WaveOutPCMOutputDriver.cpp
@@ -188,7 +188,7 @@ namespace Aws
                         CapabilityInfo capsInfo;
                         capsInfo.channels = MONO;
                         capsInfo.sampleRate = KHZ_22_5;
-                        capsInfo.sampleWidthBits = KHZ_16;
+                        capsInfo.sampleWidthBits = BIT_WIDTH_16;
 
                         devInfo.capabilities.push_back(capsInfo);
                     }


### PR DESCRIPTION
Mirror of aws aws-sdk-cpp#681
Fixed a typo where someone used KHZ_16 as a bit width.
We definitely don't have 16000 bit wide audio.  ;-)
one line change to BIT_WIDTH_16
